### PR TITLE
fix(MondayService): handle missing settings string for mirror columns…

### DIFF
--- a/common/services/monday.py
+++ b/common/services/monday.py
@@ -594,9 +594,7 @@ class MondayService(BaseService):
                 self.logger.error(f"Error evaluating formula: {e}")
 
         elif column["type"] == "mirror":
-            settings_str = column["column"].get("settings_str")
-            if not settings_str:
-                raise Exception(f"No settings string found for mirror column: {column}")
+            settings_str = column["column"].get("settings_str") or "{}"
             settings = json.loads(settings_str)
             # Settings string example: "{\"relation_column\":{\"subitems\":true},\"displayed_column\":{},\"displayed_linked_columns\":{\"4154746971\":[\"numeric_mkpy9ap3\"]},\"function\":\"sum\"}"
             # If the function is a math function, we need to apply it to the values of the mirrored items


### PR DESCRIPTION
… by providing a default empty JSON object